### PR TITLE
Bugfix: New syntax for OpenSSL

### DIFF
--- a/lib/ant.rb
+++ b/lib/ant.rb
@@ -50,7 +50,7 @@ module Ant
 
     def signature
       str = self.username + self.api_key + self.nonce_v
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), self.api_secret ,str)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), self.api_secret ,str)
     end
 
     def post(url, param)


### PR DESCRIPTION
Newer versions of OpenSSL have a different syntax and so your code produces the warning output:

Digest::Digest is deprecated; use Digest
